### PR TITLE
Suggest snappier shortDescription

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -114,7 +114,7 @@ const pkgdef :Spk.PackageDefinition = (
       # in an app store. Note that the Markdown is not permitted to contain HTML nor image tags (but
       # you can include a list of screenshots separately).
 
-      shortDescription = (defaultText = "Encrypted Storage"),
+      shortDescription = (defaultText = "Store secrets safely"),
       # A very short (one-to-three words) description of what the app does. For example,
       # "Document editor", or "Notetaking", or "Email client". This will be displayed under the app
       # title in the grid view in the app market.


### PR DESCRIPTION
Rationale:

- When I see "encrypted storage" I think "of big files, like dropbox", but when I see "Store secrets safely" I think secrets are probably small.

- Also, it's important to only capitalize it as "Encrypted storage" not "Encrypted Storage" since other apps don't capitalize their second letter.